### PR TITLE
Feature cache previous ray start

### DIFF
--- a/Main.asm
+++ b/Main.asm
@@ -103,6 +103,14 @@ setup
                 jsr player_setup
                 jsr screen_setup
                 jsr irq_setup
+
+                lda #0
+                ldx #SCREEN_WIDTH -1
+@loop           
+                sta rayStart,x
+                dex
+
+                bpl @loop
                 rts
 
 ;;---------------------------------------------

--- a/ray.asm
+++ b/ray.asm
@@ -6,7 +6,7 @@ stepX=$6d
 stepY=$6e
 
 rayId=$6f
-thetaRayZero=$70
+FREE=$70
 
 texture=$75
 texture_L=$75

--- a/ray.asm
+++ b/ray.asm
@@ -37,6 +37,7 @@ textureMapCode=$7A
 rayStart=$C000
 rayTextureId=$C028
 texColumnOffsets=$C050
+prevRayStart=$C078
 backBuffer=$C800
 
 TEXTURE_1_ID=#0

--- a/renderer.asm
+++ b/renderer.asm
@@ -2,7 +2,6 @@ f_8=$74
 g_8=$77
 prevTextureId=$78
 rayStartX=$7b
-prevRayStartX=$7e
 texMapCoordsIdx=$7c
 currTexColumnOffset=$7d
 ;;---------------------------------------------
@@ -58,8 +57,6 @@ draw_back_buffer
 
                         ldy rayStart,x
                         sty rayStartX
-                        lda prevRayStart,x
-                        sta prevRayStartX
                         lda texColumnOffsets,x          ; beginning of a texture vertical strip
                         sta currTexColumnOffset         ;
                         lda textureMappingOffsets,y     ; beginning of list of "steps" for every rayStart
@@ -85,12 +82,15 @@ draw_back_buffer
                         cpy rayStartX
                         bcs @draw_walls
                         
+                        
+                        ldx g_8
+@draw_ceil_and_floor    
                         lda CEIL_FLOOR_COLOR
-@draw_ceil_and_floor            
                         sta (E_16),y
                         dey
                         bmi @end
-                        cpy prevRayStartX
+                        tya
+                        cmp prevRayStart,x
                         bcs @draw_ceil_and_floor
 
 @end               

--- a/renderer.asm
+++ b/renderer.asm
@@ -88,13 +88,14 @@ draw_back_buffer
                         lda CEIL_FLOOR_COLOR
                         sta (E_16),y
                         dey
-                        bmi @end
+                        bmi @end_ceil_floor ; workarount to skip redundant ldx
                         tya
                         cmp prevRayStart,x
                         bcs @draw_ceil_and_floor
 
 @end               
                 ldx g_8
+@end_ceil_floor
                 dex
                 bpl @cols
                 rts

--- a/renderer.asm
+++ b/renderer.asm
@@ -2,6 +2,7 @@ f_8=$74
 g_8=$77
 prevTextureId=$78
 rayStartX=$7b
+prevRayStartX=$7e
 texMapCoordsIdx=$7c
 currTexColumnOffset=$7d
 ;;---------------------------------------------
@@ -56,7 +57,9 @@ draw_back_buffer
                         sta E_16_H
 
                         ldy rayStart,x
-                        sty rayStartX                   
+                        sty rayStartX
+                        lda prevRayStart,x
+                        sta prevRayStartX
                         lda texColumnOffsets,x          ; beginning of a texture vertical strip
                         sta currTexColumnOffset         ;
                         lda textureMappingOffsets,y     ; beginning of list of "steps" for every rayStart
@@ -81,11 +84,14 @@ draw_back_buffer
                         bmi @end
                         cpy rayStartX
                         bcs @draw_walls
+                        
                         lda CEIL_FLOOR_COLOR
 @draw_ceil_and_floor            
                         sta (E_16),y
                         dey
-                        bpl @draw_ceil_and_floor
+                        bmi @end
+                        cpy prevRayStartX
+                        bcs @draw_ceil_and_floor
 
 @end               
                 ldx g_8

--- a/renderer.asm
+++ b/renderer.asm
@@ -11,18 +11,16 @@ currTexColumnOffset=$7d
 ;;---------------------------------------------
 compute_frame   
                 lda playerTheta
-                sec
-                sbc HALF_FOV
-                sta thetaRayZero
+                clc
+                adc HALF_FOV
+                sta rayTheta
 
                 ldx #SCREEN_WIDTH -1
                 stx rayId
-@loop                   lda thetaRayZero
-                        adc rayId
-                        sta rayTheta
-
+@loop                   
                         jsr init_ray_params
                         jsr cast_ray
+                        dec rayTheta
                 dec rayId 
                 bpl @loop
                 rts

--- a/utils.asm
+++ b/utils.asm
@@ -53,7 +53,8 @@ defm lineStartRow
         
         tay
         ldx rayId
-
+        lda rayStart,x
+        sta prevRayStart,x
         lda (E_16),y        
         sta rayStart,x
         


### PR DESCRIPTION
Ceil pixels are drawn only when the line height gets lower from frame to frame, to cover previous line.